### PR TITLE
Fix symbol upload script.

### DIFF
--- a/Anypic-iOS/Anypic.xcodeproj/project.pbxproj
+++ b/Anypic-iOS/Anypic.xcodeproj/project.pbxproj
@@ -964,7 +964,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=/usr/local/bin:$PATH\n# Update the following with the path to your Cloud Code\ncd /Users/hramos/git/Anypic/Anypic-cloud\n\nparse symbols \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"";
+			shellScript = "export PATH=/usr/local/bin:$PATH\n# Update the following with the path to your Cloud Code\ncd $PROJECT_DIR/../Anypic-cloud\n\n#parse symbols \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This fixes the relative vs absolute paths in `Upload Symbols File` build phase.
Before:
`cd /Users/hramos/git/Anypic/Anypic-cloud`
After:
`cd $PROJECT_DIR/../Anypic-cloud`