### PR TITLE
Change the way to present account and friend page

### DIFF
--- a/Anypic-iOS/Anypic/PAPAccountViewController.m
+++ b/Anypic-iOS/Anypic/PAPAccountViewController.m
@@ -48,6 +48,19 @@
 
     self.navigationItem.titleView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"LogoNavigationBar.png"]];
     
+    if (self.navigationController.viewControllers[0] == self) {
+        UIBarButtonItem *dismissLeftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Back"
+                                                                                     style:UIBarButtonItemStylePlain
+                                                                                    target:self
+                                                                                    action:@selector(dismissPresentingViewController)];
+        
+        self.navigationItem.leftBarButtonItem = dismissLeftBarButtonItem;
+    }
+    else {
+        self.navigationItem.leftBarButtonItem = nil;
+    }
+    
+    
     self.headerView = [[UIView alloc] initWithFrame:CGRectMake( 0.0f, 0.0f, self.tableView.bounds.size.width, 222.0f)];
     [self.headerView setBackgroundColor:[UIColor clearColor]]; // should be clear, this will be the container for our avatar, photo count, follower count, following count, and so on
     
@@ -219,6 +232,10 @@
             }
         }];
     }
+}
+
+- (void)dismissPresentingViewController {
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - PFQueryTableViewController

--- a/Anypic-iOS/Anypic/PAPActivityFeedViewController.m
+++ b/Anypic-iOS/Anypic/PAPActivityFeedViewController.m
@@ -18,9 +18,11 @@
 #import "MBProgressHUD.h"
 #import "AppDelegate.h"
 
-@interface PAPActivityFeedViewController ()
+@interface PAPActivityFeedViewController () <UIActionSheetDelegate>
 
 @property (nonatomic, strong) PAPSettingsActionSheetDelegate *settingsActionSheetDelegate;
+@property (nonatomic, strong) UINavigationController *presentingAccountNavController;
+@property (nonatomic, strong) UINavigationController *presentingFriendNavController;
 @property (nonatomic, strong) NSDate *lastRefresh;
 @property (nonatomic, strong) UIView *blankTimelineView;
 @end
@@ -60,6 +62,24 @@
 
 
 #pragma mark - UIViewController
+
+- (UINavigationController *)presentingAccountNavController {
+    if (!_presentingAccountNavController) {
+        
+        PAPAccountViewController *accountViewController = [[PAPAccountViewController alloc] initWithUser:[PFUser currentUser]];
+        _presentingAccountNavController = [[UINavigationController alloc] initWithRootViewController:accountViewController];
+    }
+    return _presentingAccountNavController;
+}
+
+- (UINavigationController *)presentingFriendNavController {
+    if (!_presentingFriendNavController) {
+        
+        PAPFindFriendsViewController *findFriendsVC = [[PAPFindFriendsViewController alloc] init];
+        _presentingFriendNavController = [[UINavigationController alloc] initWithRootViewController:findFriendsVC];
+    }
+    return _presentingFriendNavController;
+}
 
 - (void)viewDidLoad {
     [self.tableView setSeparatorStyle:UITableViewCellSeparatorStyleSingleLine];
@@ -283,8 +303,7 @@
 #pragma mark - ()
 
 - (void)settingsButtonAction:(id)sender {
-    settingsActionSheetDelegate = [[PAPSettingsActionSheetDelegate alloc] initWithNavigationController:self.navigationController];
-    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:settingsActionSheetDelegate cancelButtonTitle:@"Cancel" destructiveButtonTitle:nil otherButtonTitles:NSLocalizedString(@"My Profile", nil), NSLocalizedString(@"Find Friends", nil), NSLocalizedString(@"Log Out", nil), nil];
+    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:nil otherButtonTitles:@"My Profile",@"Find Friends",@"Log Out", nil];
     
     [actionSheet showFromTabBar:self.tabBarController.tabBar];
 }
@@ -296,6 +315,31 @@
 
 - (void)applicationDidReceiveRemoteNotification:(NSNotification *)note {
     [self loadObjects];
+}
+
+#pragma mark - UIActionSheetDelegate
+- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
+    
+    switch (buttonIndex) {
+        case 0: {
+            [self presentViewController:self.presentingAccountNavController animated:YES completion:nil];
+            
+            break;
+        }
+            
+        case 1: {
+            [self presentViewController:self.presentingFriendNavController animated:YES completion:nil];
+            break;
+        }
+            
+        case 2: {
+            // Log out user and present the login view controller
+            [(AppDelegate *)[[UIApplication sharedApplication] delegate] logOut];
+        }
+            
+        default:
+            break;
+    }
 }
 
 @end

--- a/Anypic-iOS/Anypic/PAPFindFriendsViewController.m
+++ b/Anypic-iOS/Anypic/PAPFindFriendsViewController.m
@@ -69,6 +69,18 @@ typedef enum {
     self.tableView.backgroundColor = [UIColor blackColor];
 
     self.navigationItem.titleView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"TitleFindFriends.png"]];
+    
+    if (self.navigationController.viewControllers[0] == self) {
+        UIBarButtonItem *dismissLeftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Back"
+                                                                                     style:UIBarButtonItemStylePlain
+                                                                                    target:self
+                                                                                    action:@selector(dismissPresentingViewController)];
+        
+        self.navigationItem.leftBarButtonItem = dismissLeftBarButtonItem;
+    }
+    else {
+        self.navigationItem.leftBarButtonItem = nil;
+    }
 
     if ([MFMailComposeViewController canSendMail] || [MFMessageComposeViewController canSendText]) {
         self.headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 67)];
@@ -98,6 +110,10 @@ typedef enum {
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     self.tableView.separatorColor = [UIColor colorWithRed:30.0f/255.0f green:30.0f/255.0f blue:30.0f/255.0f alpha:1.0f];
+}
+
+- (void)dismissPresentingViewController {
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - UITableViewDelegate

--- a/Anypic-iOS/Anypic/PAPHomeViewController.m
+++ b/Anypic-iOS/Anypic/PAPHomeViewController.m
@@ -10,10 +10,14 @@
 #import "PAPSettingsActionSheetDelegate.h"
 #import "PAPSettingsButtonItem.h"
 #import "PAPFindFriendsViewController.h"
+#import "PAPAccountViewController.h"
 #import "MBProgressHUD.h"
+#import "AppDelegate.h"
 
-@interface PAPHomeViewController ()
+@interface PAPHomeViewController () <UIActionSheetDelegate>
 @property (nonatomic, strong) PAPSettingsActionSheetDelegate *settingsActionSheetDelegate;
+@property (nonatomic, strong) UINavigationController *presentingAccountNavController;
+@property (nonatomic, strong) UINavigationController *presentingFriendNavController;
 @property (nonatomic, strong) UIView *blankTimelineView;
 @end
 
@@ -24,6 +28,24 @@
 
 
 #pragma mark - UIViewController
+
+- (UINavigationController *)presentingAccountNavController {
+    if (!_presentingAccountNavController) {
+        
+        PAPAccountViewController *accountViewController = [[PAPAccountViewController alloc] initWithUser:[PFUser currentUser]];
+        _presentingAccountNavController = [[UINavigationController alloc] initWithRootViewController:accountViewController];
+    }
+    return _presentingAccountNavController;
+}
+
+- (UINavigationController *)presentingFriendNavController {
+    if (!_presentingFriendNavController) {
+        
+        PAPFindFriendsViewController *findFriendsVC = [[PAPFindFriendsViewController alloc] init];
+        _presentingFriendNavController = [[UINavigationController alloc] initWithRootViewController:findFriendsVC];
+    }
+    return _presentingFriendNavController;
+}
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -68,8 +90,7 @@
 #pragma mark - ()
 
 - (void)settingsButtonAction:(id)sender {
-    self.settingsActionSheetDelegate = [[PAPSettingsActionSheetDelegate alloc] initWithNavigationController:self.navigationController];
-    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self.settingsActionSheetDelegate cancelButtonTitle:@"Cancel" destructiveButtonTitle:nil otherButtonTitles:@"My Profile",@"Find Friends",@"Log Out", nil];
+    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:nil otherButtonTitles:@"My Profile",@"Find Friends",@"Log Out", nil];
     
     [actionSheet showFromTabBar:self.tabBarController.tabBar];
 }
@@ -79,4 +100,30 @@
     PAPFindFriendsViewController *detailViewController = [[PAPFindFriendsViewController alloc] init];
     [self.navigationController pushViewController:detailViewController animated:YES];
 }
+
+#pragma mark - UIActionSheetDelegate
+- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
+    
+    switch (buttonIndex) {
+        case 0: {
+            [self presentViewController:self.presentingAccountNavController animated:YES completion:nil];
+            
+            break;
+        }
+        
+        case 1: {
+            [self presentViewController:self.presentingFriendNavController animated:YES completion:nil];
+            break;
+        }
+            
+        case 2: {
+            // Log out user and present the login view controller
+            [(AppDelegate *)[[UIApplication sharedApplication] delegate] logOut];
+        }
+            
+        default:
+            break;
+    }
+}
+
 @end


### PR DESCRIPTION
Instead of use the main `UINavigationController` to push the account and friend pages when you click on the setting button on the top right corner, I changed to use the modal way to present it. It prevents a potential bug that will cause user page being pushed infinitely. From the UX standpoint, due to account and friends pages are not directly relevant to the main page, it's better to use presentation. 