### PR TITLE
Fix for profile image corner radius on photo details view

### DIFF
--- a/Anypic-iOS/Anypic/PAPPhotoDetailsHeaderView.m
+++ b/Anypic-iOS/Anypic/PAPPhotoDetailsHeaderView.m
@@ -249,7 +249,7 @@ static TTTTimeIntervalFormatter *timeFormatter;
         [avatarImageView setOpaque:NO];
         [avatarImageView.profileButton addTarget:self action:@selector(didTapUserNameButtonAction:) forControlEvents:UIControlEventTouchUpInside];
         [avatarImageView setContentMode:UIViewContentModeScaleAspectFill];
-        avatarImageView.layer.cornerRadius = 66.0f;
+        avatarImageView.layer.cornerRadius = avatarImageDim / 2.0f;
         avatarImageView.layer.masksToBounds = YES;
         //[avatarImageView load:^(UIImage *image, NSError *error) {}];
         [nameHeaderView addSubview:avatarImageView];


### PR DESCRIPTION
In the photo details view, the user's profile image was blank because the corner radius of the PAPProfileImageView control was set to a fixed 66px, while the profile image size was only 35px. The expected effect was to have a round profile picture, so the code has been changed to fix this.